### PR TITLE
Make URL for fetching channel ID configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ You can configure integration_name through the authorize_params hash:
 end
 ```
 
+### Configure for Sandbox ENV
+
+Configure these options to use ShipBob's [sandbox](https://developer.shipbob.com/sandbox-simulations) environment.
+
+```ruby
+  Rails.application.config.middleware.use OmniAuth::Builder do
+    provider :shipbob,
+           ...,
+           api_url: 'https://sandbox-api.shipbob.com/2.0',
+           client_options: {
+             site: 'https://authstage.shipbob.com'
+           },
+end
+```
+
 
 ## Development
 

--- a/lib/omniauth/strategies/shipbob.rb
+++ b/lib/omniauth/strategies/shipbob.rb
@@ -13,6 +13,7 @@ module OmniAuth
       }
       
       option :authorize_params, { :response_mode => 'form_post' }
+      option :api_url, 'https://api.shipbob.com/1.0'
       
       credentials do
         hash = {"token" => access_token.token}
@@ -25,7 +26,7 @@ module OmniAuth
       
       def get_channel_id(token)
         log :info, 'Calling API to get Channel Id.'
-        response = token.get('https://api.shipbob.com/1.0/channel', :headers => { 'Content-Type' => 'application/json' })
+        response = token.get("#{options.api_url}/channel", :headers => { 'Content-Type' => 'application/json' })
         JSON.parse(response.body).dig(0, "id")
       rescue => e
         nil  

--- a/spec/omniauth/strategies/shipbob_spec.rb
+++ b/spec/omniauth/strategies/shipbob_spec.rb
@@ -17,4 +17,22 @@ RSpec.describe OmniAuth::Strategies::Shipbob do
       expect(subject.token_url).to eq('/connect/token')
     end
   end
+
+  describe '#options' do
+    subject { strategy.new(app).options }
+
+    it 'should have default api_url' do
+      expect(subject.api_url).to eq('https://api.shipbob.com/1.0')
+    end
+
+    context 'when api_url is set' do
+      let(:staging_api_url) { 'https://example.com/1.0' }
+
+      subject { strategy.new(app, { api_url: staging_api_url }).options }
+  
+      it 'should have correct api_url' do
+        expect(subject.api_url).to eq(staging_api_url)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Make the URL for fetching channel ID a config option. This makes it possible to use ShipBob's Sandbox environment while in development. 

### Example

```ruby
Rails.application.config.middleware.use OmniAuth::Builder do
  provider :shipbob,
    ...,
    api_url: 'https://sandbox-api.shipbob.com/2.0',
    client_options: {
      site: 'https://authstage.shipbob.com'
    },
end
```